### PR TITLE
Added support for bookmarks

### DIFF
--- a/HgPrompt.ps1
+++ b/HgPrompt.ps1
@@ -40,10 +40,17 @@ function Write-HgStatus($status = (get-hgStatus)) {
 
         if($s.ShowTags -and $status.Tags.Length) {
           write-host $s.BeforeTagText -NoNewLine
-          
+         
           $tagCounter=0
           $status.Tags | % {
-              write-host $_ -NoNewLine -ForegroundColor $s.TagForegroundColor -BackgroundColor $s.TagBackgroundColor 
+            $color = $s.TagForegroundColor
+            
+            if($_.Trim() -eq $status.ActiveBookmark) {
+                $color = $s.BranchForegroundColor
+            }
+                
+              write-host $_ -NoNewLine -ForegroundColor $color -BackgroundColor $s.TagBackgroundColor 
+          
               if($tagCounter -lt ($status.Tags.Length -1)) {
                 write-host ", " -NoNewLine -ForegroundColor $s.TagSeparatorColor -BackgroundColor $s.TagBackgroundColor
               }

--- a/HgUtils.ps1
+++ b/HgUtils.ps1
@@ -32,8 +32,9 @@ function Get-HgStatus {
     $tags = @()
     $commit = ""
     $behind = $false
-    
-    hg summary | foreach {   
+   
+  
+       hg summary | foreach {   
       switch -regex ($_) {
         'parent: (\S*) ?(.*)' { $commit = $matches[1]; $tags = $matches[2].Replace("(empty repository)", "").Split(" ", [StringSplitOptions]::RemoveEmptyEntries) } 
         'branch: (\S*)' { $branch = $matches[1] }
@@ -54,6 +55,14 @@ function Get-HgStatus {
       } 
     }
     
+    $active = ""
+    hg bookmarks | ?{$_}  | foreach {
+        if($_.Trim().StartsWith("*")) {
+           $split = $_.Split(" ");
+           $active= $split[2]
+        }
+    }
+   
     return @{"Untracked" = $untracked;
                "Added" = $added;
                "Modified" = $modified;
@@ -63,6 +72,7 @@ function Get-HgStatus {
                "Tags" = $tags;
                "Commit" = $commit;
                "Behind" = $behind;
+               "ActiveBookmark" = $active;
                "Branch" = $branch}
    }
 }


### PR DESCRIPTION
We are using bookmarks as the branching strategy for hg and found that the posh-hg didn't support what we needed.  Hopefully you and others will find this useful.
- Added the tab support for retrieving local and remote bookmarks.  
  *\* hg pull -B <bookmark>
  *\* hg push -B <bookmark>
  *\* hg up|update|merge|co|checkout <bookmark>
  *\* hg book|bookmark <bookmark>
- Added the active bookmark in the powershell prompt so you can see which bookmark is currently active.
- All other commands remained the same
