### PR TITLE
Fixed bug displaying branch names with spaces

### DIFF
--- a/HgUtils.ps1
+++ b/HgUtils.ps1
@@ -37,7 +37,7 @@ function Get-HgStatus {
        hg summary | foreach {   
       switch -regex ($_) {
         'parent: (\S*) ?(.*)' { $commit = $matches[1]; $tags = $matches[2].Replace("(empty repository)", "").Split(" ", [StringSplitOptions]::RemoveEmptyEntries) } 
-        'branch: (\S*)' { $branch = $matches[1] }
+        'branch: ([\S ]*)' { $branch = $matches[1] }
         'update: (\d+)' { $behind = $true }
         'pmerge: (\d+) pending' { $behind = $true }
         'commit: (.*)' {


### PR DESCRIPTION
Fixed an issue where branch names with spaces would only display the first word as the branch name in the prompt.

Example: branch name `Hotfix 101` would show as `Hotfix` in the PS prompt. Now it shows as `Hotfix 101`.
