### PR TITLE
Fixed support for bookmarks

### DIFF
--- a/HgPrompt.ps1
+++ b/HgPrompt.ps1
@@ -38,16 +38,19 @@ function Write-HgStatus($status = (get-hgStatus)) {
            Write-Host " ^$($status.Renamed)" -NoNewline -BackgroundColor $s.RenamedBackgroundColor -ForegroundColor $s.RenamedForegroundColor
         }
 
-        if($s.ShowTags -and $status.Tags.Length) {
+        if($s.ShowTags -and ($status.Tags.Length -or $status.ActiveBookmark.Length)) {
           write-host $s.BeforeTagText -NoNewLine
+            
+          if($status.ActiveBookmark.Length) {
+              write-host $status.ActiveBookmark -NoNewLine -ForegroundColor $s.BranchForegroundColor -BackgroundColor $s.TagBackgroundColor 
+              if($status.Tags.Length) {
+                write-host " " -NoNewLine -ForegroundColor $s.TagSeparatorColor -BackgroundColor $s.TagBackgroundColor
+              }
+          }
          
           $tagCounter=0
           $status.Tags | % {
             $color = $s.TagForegroundColor
-            
-            if($_.Trim() -eq $status.ActiveBookmark) {
-                $color = $s.BranchForegroundColor
-            }
                 
               write-host $_ -NoNewLine -ForegroundColor $color -BackgroundColor $s.TagBackgroundColor 
           


### PR DESCRIPTION
Posh-Hg was not showing bookmarks in my repositories.  Looks like a change in the hg summary command introduced in 2.0(?) broke the bookmark support. Here are the changes I made to get it to work again.
