### PR TITLE
Windows 8 consumer preview clean install issue

### DIFF
--- a/HgTabExpansion.ps1
+++ b/HgTabExpansion.ps1
@@ -240,7 +240,7 @@ function thgCommands($filter) {
   $cmdList | sort 
 }
 
-if(-not (Test-Path Function:\DefaultTabExpansion)) {
+if((Test-Path Function:\TabExpansion) -and (-not (Test-Path Function:\DefaultTabExpansion))) {
    Rename-Item Function:\TabExpansion DefaultTabExpansion
 }
 


### PR DESCRIPTION
On Windows 8 consumer preview (64 bit) clean install I was getting the following message with posh-hg:

Rename-Item : Cannot rename because item at 'Function:\TabExpansion' does not
exist.
At C:\d\bin\posh-hg\HgTabExpansion.ps1:244 char:4
-    Rename-Item Function:\TabExpansion DefaultTabExpansion
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  - CategoryInfo          : InvalidOperation: (:) [Rename-Item], PSInvalidOp
    erationException
  - FullyQualifiedErrorId : InvalidOperation,Microsoft.PowerShell.Commands.R
    enameItemCommand

It looks like the TabExpansion function isn't there, so while the condition -not (Test-Path Function:\DefaultTabExpansion) on line 243 of HgTabExpansion succeeds, the actual rename will fail.

I put in an additional check for the TabExpansion to exist prior to attempting the rename.  
