### PR TITLE
Make status prefix in prompt configurable. Fixes issue #11.

### DIFF
--- a/HgPrompt.ps1
+++ b/HgPrompt.ps1
@@ -17,25 +17,25 @@ function Write-HgStatus($status = (get-hgStatus)) {
         Write-Host $status.Branch -NoNewline -BackgroundColor $branchBg -ForegroundColor $branchFg
         
         if($status.Added) {
-          Write-Host " +$($status.Added)" -NoNewline -BackgroundColor $s.AddedBackgroundColor -ForegroundColor $s.AddedForegroundColor
+          Write-Host "$($s.AddedStatusPrefix)$($status.Added)" -NoNewline -BackgroundColor $s.AddedBackgroundColor -ForegroundColor $s.AddedForegroundColor
         }
         if($status.Modified) {
-          Write-Host " ~$($status.Modified)" -NoNewline -BackgroundColor $s.ModifiedBackgroundColor -ForegroundColor $s.ModifiedForegroundColor
+          Write-Host "$($s.ModifiedStatusPrefix)$($status.Modified)" -NoNewline -BackgroundColor $s.ModifiedBackgroundColor -ForegroundColor $s.ModifiedForegroundColor
         }
         if($status.Deleted) {
-          Write-Host " -$($status.Deleted)" -NoNewline -BackgroundColor $s.DeletedBackgroundColor -ForegroundColor $s.DeletedForegroundColor
+          Write-Host "$($s.DeletedStatusPrefix)$($status.Deleted)" -NoNewline -BackgroundColor $s.DeletedBackgroundColor -ForegroundColor $s.DeletedForegroundColor
         }
         
         if ($status.Untracked) {
-          Write-Host " ?$($status.Untracked)" -NoNewline -BackgroundColor $s.UntrackedBackgroundColor -ForegroundColor $s.UntrackedForegroundColor
+          Write-Host "$($s.UntrackedStatusPrefix)$($status.Untracked)" -NoNewline -BackgroundColor $s.UntrackedBackgroundColor -ForegroundColor $s.UntrackedForegroundColor
         }
         
         if($status.Missing) {
-           Write-Host " !$($status.Missing)" -NoNewline -BackgroundColor $s.MissingBackgroundColor -ForegroundColor $s.MissingForegroundColor
+           Write-Host "$($s.MissingStatusPrefix)$($status.Missing)" -NoNewline -BackgroundColor $s.MissingBackgroundColor -ForegroundColor $s.MissingForegroundColor
         }
 
         if($status.Renamed) {
-           Write-Host " ^$($status.Renamed)" -NoNewline -BackgroundColor $s.RenamedBackgroundColor -ForegroundColor $s.RenamedForegroundColor
+           Write-Host "$($s.RenamedStatusPrefix)$($status.Renamed)" -NoNewline -BackgroundColor $s.RenamedBackgroundColor -ForegroundColor $s.RenamedForegroundColor
         }
 
         if($s.ShowTags -and ($status.Tags.Length -or $status.ActiveBookmark.Length)) {

--- a/Settings.ps1
+++ b/Settings.ps1
@@ -47,4 +47,12 @@ $global:PoshHgSettings = New-Object PSObject -Property @{
     AppliedPatchBackgroundColor   = $Host.UI.RawUI.BackgroundColor
     PatchSeparator                = ' › '
     PatchSeparatorColor           = [ConsoleColor]::White    
+    
+    # Status Count Prefixes for prompt
+    AddedStatusPrefix             = ' +'
+    ModifiedStatusPrefix          = ' ~'
+    DeletedStatusPrefix           = ' -'
+    UntrackedStatusPrefix         = ' ?'
+    MissingStatusPrefix           = ' !'
+    RenamedStatusPrefix           = ' ^'
 }


### PR DESCRIPTION
Would be nice if someone verifies that the way I'm concatenating in Write-Host is OK; I'm not great at Powershell.
