### PR TITLE
Improving performance - making 'hg summary' optional

### DIFF
--- a/HgPrompt.ps1
+++ b/HgPrompt.ps1
@@ -12,6 +12,11 @@ function Write-HgStatus($status = (get-hgStatus $global:PoshHgSettings.GetFileSt
           $branchFg = $s.Branch2ForegroundColor
           $branchBg = $s.Branch2BackgroundColor
         }
+
+        if ($status.MultipleHeads) {
+          $branchFg = $s.Branch3ForegroundColor
+          $branchBg = $s.Branch3BackgroundColor
+        }
        
         Write-Host $s.BeforeText -NoNewline -BackgroundColor $s.BeforeBackgroundColor -ForegroundColor $s.BeforeForegroundColor
         Write-Host $status.Branch -NoNewline -BackgroundColor $branchBg -ForegroundColor $branchFg

--- a/HgUtils.ps1
+++ b/HgUtils.ps1
@@ -34,8 +34,8 @@ function Get-HgStatus($getFileStatus=$true, $getBookmarkStatus=$true) {
     $tags = @()
     $commit = ""
     $behind = $false
-	
-	
+    $multipleHeads = $false
+		
 	if ($getFileStatus -eq $false) {
 		hg parent | foreach {
 		switch -regex ($_) {
@@ -45,9 +45,15 @@ function Get-HgStatus($getFileStatus=$true, $getBookmarkStatus=$true) {
 		}
 		$branch = hg branch
 		$behind = $true
+		$headCount = 0
 		hg heads $branch | foreach {
 			switch -regex ($_) {
-				'changeset:\s*(\S*)' { if ($commit -eq $matches[1]) { $behind=$false } }
+				'changeset:\s*(\S*)' 
+				{ 
+					if ($commit -eq $matches[1]) { $behind=$false }
+					$headCount++
+					if ($headCount -gt 1) { $multipleHeads=$true }
+				}
 			}
 		}
 	}
@@ -95,6 +101,7 @@ function Get-HgStatus($getFileStatus=$true, $getBookmarkStatus=$true) {
                "Tags" = $tags;
                "Commit" = $commit;
                "Behind" = $behind;
+               "MultipleHeads" = $multipleHeads;
                "ActiveBookmark" = $active;
                "Branch" = $branch}
    }

--- a/Settings.ps1
+++ b/Settings.ps1
@@ -19,6 +19,9 @@ $global:PoshHgSettings = New-Object PSObject -Property @{
     # Current branch when not updated
     Branch2ForegroundColor   = [ConsoleColor]::Red
     Branch2BackgroundColor   = $host.UI.RawUI.BackgroundColor
+    # Current branch when there are multiple heads
+    Branch3ForegroundColor	 = [ConsoleColor]::Magenta
+    Branch3BackgroundColor   = $host.UI.RawUI.BackgroundColor
     
     # Working directory status
     AddedForegroundColor      = [ConsoleColor]::Green


### PR DESCRIPTION
When using posh-hg on large repositories, retreiving the status of pending changes can be _very_ time consuming. By making this optional (so far on a global level), the performance of posh-hg improves whilst still keeping several of the core features of posh-hg, namely branch name, tag names, and whether we are behind or not.
