### PR TITLE
Use $(hg root) for hg files function to get relative paths

### DIFF
--- a/HgTabExpansion.ps1
+++ b/HgTabExpansion.ps1
@@ -71,7 +71,7 @@ function HgTabExpansion($lastBlock) {
 }
 
 function hgFiles($filter, $pattern) {
-   hg status | 
+   hg status $(hg root) | 
     foreach { 
       if($_ -match "($pattern){1} (.*)") { 
         $matches[2] 


### PR DESCRIPTION
When i'm in a directory under my top level Hg directory, tab completion for `hg diff` command (`add` too!) will give the path relative from the root directory of the repository. If i'm in a subdirectory than running the completed command will explode! 

:bomb: `The system cannot find the path specified` :bomb:

i haven't thought through how this will affect other commands... but i didn't want to create an issue without at least sending some suggestion of how it could look.
