### PR TITLE
Added Get-AliasPattern to HgUtils similar to how it is in GitUtils

### DIFF
--- a/HgUtils.ps1
+++ b/HgUtils.ps1
@@ -135,3 +135,8 @@ function Get-MqPatches($filter) {
     "Applied" = $applied
   }
 }
+
+function Get-AliasPattern($exe) {
+  $aliases = @($exe) + @(Get-Alias | where { $_.Definition -eq $exe } | select -Exp Name)
+  "($($aliases -join '|'))"
+}


### PR DESCRIPTION
When I pulled in the latest it initially wasn't working because of a missing Get-AliasPattern. I suspect it's because I don't have posh-git also in my profile. I Added the function to HgUtils though in a similar way and now it works just fine.
