### PR TITLE
Added hg flow patterns to HgTabExpansion

### DIFF
--- a/HgTabExpansion.ps1
+++ b/HgTabExpansion.ps1
@@ -77,6 +77,7 @@ function HgTabExpansion($lastBlock) {
     #handles hg flow *
     'hg flow (\S*)$' {
       hgflowStreams($matches[1])
+      hgLocalBranches($matches[1])
     }
   }
 }


### PR DESCRIPTION
Since we switch to using hgflow I was missing my tab completion on branches. This added tab completion around hotfix,feature,support and release and filters for just those specific branches.
