### PR TITLE
Use $pwd.ProviderPath for the prompt

### DIFF
--- a/HgPrompt.ps1
+++ b/HgPrompt.ps1
@@ -104,9 +104,9 @@ function Write-HgStatus($status = (get-hgStatus $global:PoshHgSettings.GetFileSt
 }
 
 # Should match https://github.com/dahlbyk/posh-git/blob/master/GitPrompt.ps1
-if((Get-Variable -Scope Global -Name VcsPromptStatuses -ErrorAction SilentlyContinue) -eq $null) {
-    $Global:VcsPromptStatuses = @()
-}
+if(!(Test-Path Variable:Global:VcsPromptStatuses)) {
+     $Global:VcsPromptStatuses = @()
+ }
 function Global:Write-VcsStatus { $Global:VcsPromptStatuses | foreach { & $_ } }
 
 # Add scriptblock that will execute for Write-VcsStatus

--- a/HgTabExpansion.ps1
+++ b/HgTabExpansion.ps1
@@ -298,7 +298,7 @@ function populatehgflowStreams($filename) {
   $script:hgflowStreams = if ($ini["Basic"]) { $ini["Basic"] } else { $ini["branchname"] }
 }
 
-$PowerTab_RegisterTabExpansion = Get-Command Register-TabExpansion -Module powertab -ErrorAction SilentlyContinue
+$PowerTab_RegisterTabExpansion = if (Get-Module -Name powertab) { Get-Command Register-TabExpansion -Module powertab -ErrorAction SilentlyContinue }
 if ($PowerTab_RegisterTabExpansion)
 {
     & $PowerTab_RegisterTabExpansion "hg.exe" -Type Command {


### PR DESCRIPTION
As I discovered in [this SO answer](http://stackoverflow.com/a/8742417/70170), it's straightforward by using .ProviderPath to have a nicer formatting of network paths. Using .ProviderPath for the prompt keeps a useless string from leaking into the prompt.