### PR TITLE
preserve $lastexit code in function prompt()

### DIFF
--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -10,10 +10,11 @@ Import-Module .\posh-hg
 
 # Set up a simple prompt, adding the hg prompt parts inside hg repos
 function prompt {
+    $realLASTEXITCODE = $LASTEXITCODE
     Write-Host($pwd) -nonewline
 
     Write-VcsStatus
-      
+    $global:LASTEXITCODE = $realLASTEXITCODE
     return "> "
 }
 


### PR DESCRIPTION
$LASTEXITCODE gets clobbered by something in the prompt function. Save it and restore at the end.
