### PR TITLE
Use $pwd.ProviderPath for the prompt

### DIFF
--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -10,7 +10,7 @@ Import-Module .\posh-hg
 
 # Set up a simple prompt, adding the hg prompt parts inside hg repos
 function prompt {
-    Write-Host($pwd) -nonewline
+    Write-Host($pwd.ProviderPath) -nonewline
 
     Write-VcsStatus
       


### PR DESCRIPTION
As I discovered in [this SO answer](http://stackoverflow.com/a/8742417/70170), it's straightforward by using .ProviderPath to have a nicer formatting of network paths. Using .ProviderPath for the prompt keeps a useless string from leaking into the prompt.