### PR TITLE
Added the HG revison information to the prompt.

### DIFF
--- a/HgPrompt.ps1
+++ b/HgPrompt.ps1
@@ -98,6 +98,13 @@ function Write-HgStatus($status = (get-hgStatus $global:PoshHgSettings.GetFileSt
             }
           }
         }
+
+        if($status.Revision) {
+           Write-Prompt " <" -BackgroundColor $s.TagBackgroundColor -ForegroundColor $s.TagForegroundColor
+           Write-Prompt $status.Revision -BackgroundColor $s.TagBackgroundColor -ForegroundColor $s.TagForegroundColor
+           Write-Prompt ">" -BackgroundColor $s.TagBackgroundColor -ForegroundColor $s.TagForegroundColor
+        }
+
         
        Write-Prompt $s.AfterText -BackgroundColor $s.AfterBackgroundColor -ForegroundColor $s.AfterForegroundColor
     }

--- a/HgUtils.ps1
+++ b/HgUtils.ps1
@@ -35,7 +35,8 @@ function Get-HgStatus($getFileStatus=$true, $getBookmarkStatus=$true) {
     $commit = ""
     $behind = $false
     $multipleHeads = $false
-		
+    $rev = ""
+
 	if ($getFileStatus -eq $false) {
 		hg parent | foreach {
 		switch -regex ($_) {
@@ -92,6 +93,9 @@ function Get-HgStatus($getFileStatus=$true, $getBookmarkStatus=$true) {
 			}
 		}
 	}
+
+	$rev = hg log -r . --template '{rev}:{node|short}'
+
     return @{"Untracked" = $untracked;
                "Added" = $added;
                "Modified" = $modified;
@@ -103,7 +107,8 @@ function Get-HgStatus($getFileStatus=$true, $getBookmarkStatus=$true) {
                "Behind" = $behind;
                "MultipleHeads" = $multipleHeads;
                "ActiveBookmark" = $active;
-               "Branch" = $branch}
+               "Branch" = $branch
+               "Revision" = $rev}
    }
 }
 


### PR DESCRIPTION
I've found this addition useful in my daily work - thought it might be useful to others as well.

This adds both the repository-local revison number and the short version of the changeset id hash at the end of the prompt.