### PR TITLE
Added ShowRevision setting to increase options for prompt configuration

### DIFF
--- a/HgPrompt.ps1
+++ b/HgPrompt.ps1
@@ -99,7 +99,7 @@ function Write-HgStatus($status = (get-hgStatus $global:PoshHgSettings.GetFileSt
           }
         }
 
-        if($status.Revision) {
+        if($s.ShowRevision -and $status.Revision) {
            Write-Prompt " <" -BackgroundColor $s.TagBackgroundColor -ForegroundColor $s.TagForegroundColor
            Write-Prompt $status.Revision -BackgroundColor $s.TagBackgroundColor -ForegroundColor $s.TagForegroundColor
            Write-Prompt ">" -BackgroundColor $s.TagBackgroundColor -ForegroundColor $s.TagForegroundColor

--- a/Settings.ps1
+++ b/Settings.ps1
@@ -54,6 +54,9 @@ $global:PoshHgSettings = New-Object PSObject -Property @{
     AppliedPatchBackgroundColor   = $Host.UI.RawUI.BackgroundColor
     PatchSeparator                = ' › '
     PatchSeparatorColor           = [ConsoleColor]::White    
+
+    # Current revision
+    ShowRevision                = $true
     
     # Status Count Prefixes for prompt
     AddedStatusPrefix             = ' +'


### PR DESCRIPTION
The recent addition of the revision on the shell prompt is nice, but it does not suit everyone. This change introduces a default-on option to turn it off.