### PR TITLE
Adding try/catch logic to Write-VcsStatus

### DIFF
--- a/Settings.ps1
+++ b/Settings.ps1
@@ -52,8 +52,12 @@ $global:PoshHgSettings = New-Object PSObject -Property @{
     UnappliedPatchBackgroundColor = $Host.UI.RawUI.BackgroundColor
     AppliedPatchForegroundColor   = [ConsoleColor]::DarkYellow
     AppliedPatchBackgroundColor   = $Host.UI.RawUI.BackgroundColor
-    PatchSeparator                = ' › '
+    PatchSeparator                = ' â€º '
     PatchSeparatorColor           = [ConsoleColor]::White    
+ 
+    # Error customisation   
+    ErrorForegroundColor      = [ConsoleColor]::Red
+    ErrorBackgroundColor      = $Host.UI.RawUI.BackgroundColor
 
     # Current revision
     ShowRevision                = $true


### PR DESCRIPTION
Adding try/catch logic to Write-VcsStatus so that if one of the scriptblocks that has been added to the VcsPromptStatuses array fails the other scriptblocks are not affected (are still invoked)

This complements the posh-git pull request https://github.com/dahlbyk/posh-git/pull/170