### PR TITLE
Extensions and mouse left-click

### DIFF
--- a/HgTabExpansion.ps1
+++ b/HgTabExpansion.ps1
@@ -125,9 +125,13 @@ function hgCommands($filter) {
 # Invoke PopulateHgCommands in your profile if you don't want the initial hit. 
 function PopulateHgCommands() {
    $hgCommands = foreach($cmd in (hg help)) {
-    # Stop once we reach the "Enabled Extensions" section of help. 
-    # Not sure if there's a better way to do this...
+    # Enable shelve
     if($cmd -eq "enabled extensions:") {
+      continue
+    }
+    # Stop once after reaching the "Enabled Extensions" section of help. 
+    # Not sure if there's a better way to do this...
+    if($cmd -eq "additional help topics:") {
       break
     }
     

--- a/Settings.ps1
+++ b/Settings.ps1
@@ -1,15 +1,15 @@
 $global:PoshHgSettings = New-Object PSObject -Property @{
-    #Retreival settings
+    #Retrieval settings
     GetFileStatus             = $true
     GetBookmarkStatus         = $true
 	
     #Before prompt
-    BeforeText                = ' ['
+    BeforeText                = ' [ '
     BeforeForegroundColor     = [ConsoleColor]::Yellow
     BeforeBackgroundColor     = $Host.UI.RawUI.BackgroundColor
     
     #After prompt
-    AfterText                 = ']'
+    AfterText                 = ' ]'
     AfterForegroundColor      = [ConsoleColor]::Yellow
     AfterBackgroundColor      = $Host.UI.RawUI.BackgroundColor
     
@@ -52,7 +52,7 @@ $global:PoshHgSettings = New-Object PSObject -Property @{
     UnappliedPatchBackgroundColor = $Host.UI.RawUI.BackgroundColor
     AppliedPatchForegroundColor   = [ConsoleColor]::DarkYellow
     AppliedPatchBackgroundColor   = $Host.UI.RawUI.BackgroundColor
-    PatchSeparator                = ' › '
+    PatchSeparator                = ' â€º '
     PatchSeparatorColor           = [ConsoleColor]::White    
 
     # Current revision


### PR DESCRIPTION
Hi!

1. Enabled TAB extension for custom extensions like "purge", "graphlog", "shelve" (this one still requires "unshelve", though)
2. Added a whitespace in between the brackets and the branch info in the prompt, so that left-click mouse copy works without selecting a square bracket.

Cheers,
Olzhas